### PR TITLE
`mindatacarriersize`, to keep the monetary transactions out of my meme🤡pool

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -664,6 +664,11 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                              "are of this size or less, allowing multiple outputs (default: %u)",
                              MAX_OP_RETURN_RELAY),
                    ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-mindatacarriersize",
+                   strprintf("Relay and mine transactions whose data-carrying raw scriptPubKeys in aggregate "
+                             "are at least this size, allowing multiple outputs (default: %u, meaning no minimum)",
+                             MIN_OP_RETURN_RELAY),
+                   ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-permitbaremultisig", strprintf("Relay transactions creating non-P2SH multisig outputs (default: %u)", DEFAULT_PERMIT_BAREMULTISIG), ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -51,6 +51,11 @@ struct MemPoolOptions {
      * If nullopt, any size is nonstandard.
      */
     std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_OP_RETURN_RELAY} : std::nullopt};
+    /**
+     * Minimum size of TxoutType::NULL_DATA scripts that this node considers standard.
+     * If nullopt, no minimum is enforced.
+     */
+    std::optional<unsigned> min_datacarrier_bytes{std::nullopt};
     bool permit_bare_multisig{DEFAULT_PERMIT_BAREMULTISIG};
     bool require_standard{true};
     bool persist_v1_dat{DEFAULT_PERSIST_V1_DAT};

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -93,8 +93,10 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
 
     if (argsman.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER)) {
         mempool_opts.max_datacarrier_bytes = argsman.GetIntArg("-datacarriersize", MAX_OP_RETURN_RELAY);
+        mempool_opts.min_datacarrier_bytes = argsman.GetIntArg("-mindatacarriersize", MIN_OP_RETURN_RELAY);
     } else {
         mempool_opts.max_datacarrier_bytes = std::nullopt;
+        mempool_opts.min_datacarrier_bytes = std::nullopt;
     }
 
     mempool_opts.require_standard = !argsman.GetBoolArg("-acceptnonstdtxn", DEFAULT_ACCEPT_NON_STD_TXN);

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -79,6 +79,10 @@ static const bool DEFAULT_ACCEPT_DATACARRIER = true;
  */
 static const unsigned int MAX_OP_RETURN_RELAY = MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR;
 /**
+ * Default setting for -mindatacarriersize in vbytes.
+ */
+static const unsigned int MIN_OP_RETURN_RELAY = 0;
+/**
  * An extra transaction can be added to a package, as long as it only has one
  * ancestor and is no larger than this. Not really any reason to make this
  * configurable as it doesn't materially change DoS parameters.
@@ -152,7 +156,7 @@ static constexpr decltype(CTransaction::version) TX_MAX_STANDARD_VERSION{3};
 * Check for standard transaction types
 * @return True if all outputs (scriptPubKeys) use only standard transaction forms
 */
-bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason);
+bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, const std::optional<unsigned>& min_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason);
 /**
 * Check for standard transaction types
 * @param[in] mapInputs       Map of previous transactions that have outputs we're spending

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -691,6 +691,7 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     ret.pushKV("fullrbf", true);
     ret.pushKV("permitbaremultisig", pool.m_opts.permit_bare_multisig);
     ret.pushKV("maxdatacarriersize", pool.m_opts.max_datacarrier_bytes.value_or(0));
+    ret.pushKV("mindatacarriersize", pool.m_opts.min_datacarrier_bytes.value_or(0));
     return ret;
 }
 
@@ -715,6 +716,7 @@ static RPCHelpMan getmempoolinfo()
                 {RPCResult::Type::BOOL, "fullrbf", "True if the mempool accepts RBF without replaceability signaling inspection (DEPRECATED)"},
                 {RPCResult::Type::BOOL, "permitbaremultisig", "True if the mempool accepts transactions with bare multisig outputs"},
                 {RPCResult::Type::NUM, "maxdatacarriersize", "Maximum number of bytes that can be used by OP_RETURN outputs in the mempool"},
+                {RPCResult::Type::NUM, "mindatacarriersize", "Minimum number of bytes that must be used by OP_RETURN outputs in the mempool"},
             }},
         RPCExamples{
             HelpExampleCli("getmempoolinfo", "")

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -61,8 +61,8 @@ FUZZ_TARGET(transaction, .init = initialize_transaction)
 
     const CFeeRate dust_relay_fee{DUST_RELAY_TX_FEE};
     std::string reason;
-    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ true, dust_relay_fee, reason);
-    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ false, dust_relay_fee, reason);
+    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, std::nullopt, std::nullopt, /* permit_bare_multisig= */ true, dust_relay_fee, reason);
+    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, std::nullopt, std::nullopt, /* permit_bare_multisig= */ false, dust_relay_fee, reason);
     if (is_standard_without_permit_bare_multisig) {
         assert(is_standard_with_permit_bare_multisig);
     }

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -21,13 +21,13 @@
 // Helpers:
 static bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, std::string& reason)
 {
-    return IsStandardTx(tx, std::nullopt, permit_bare_multisig, CFeeRate{DUST_RELAY_TX_FEE}, reason);
+    return IsStandardTx(tx, std::nullopt, std::nullopt, permit_bare_multisig, CFeeRate{DUST_RELAY_TX_FEE}, reason);
 }
 
 static bool IsStandardTx(const CTransaction& tx, std::string& reason)
 {
-    return IsStandardTx(tx, std::nullopt, /*permit_bare_multisig=*/true, CFeeRate{DUST_RELAY_TX_FEE}, reason) &&
-           IsStandardTx(tx, std::nullopt, /*permit_bare_multisig=*/false, CFeeRate{DUST_RELAY_TX_FEE}, reason);
+    return IsStandardTx(tx, std::nullopt, std::nullopt, /*permit_bare_multisig=*/true, CFeeRate{DUST_RELAY_TX_FEE}, reason) &&
+           IsStandardTx(tx, std::nullopt, std::nullopt, /*permit_bare_multisig=*/false, CFeeRate{DUST_RELAY_TX_FEE}, reason);
 }
 
 static std::vector<unsigned char> Serialize(const CScript& s)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -800,12 +800,12 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     constexpr auto CheckIsStandard = [](const auto& t, const unsigned int max_op_return_relay = MAX_OP_RETURN_RELAY) {
         std::string reason;
-        BOOST_CHECK(IsStandardTx(CTransaction{t}, max_op_return_relay, g_bare_multi, g_dust, reason));
+        BOOST_CHECK(IsStandardTx(CTransaction{t}, max_op_return_relay, std::nullopt, g_bare_multi, g_dust, reason));
         BOOST_CHECK(reason.empty());
     };
     constexpr auto CheckIsNotStandard = [](const auto& t, const std::string& reason_in, const unsigned int max_op_return_relay = MAX_OP_RETURN_RELAY) {
         std::string reason;
-        BOOST_CHECK(!IsStandardTx(CTransaction{t}, max_op_return_relay, g_bare_multi, g_dust, reason));
+        BOOST_CHECK(!IsStandardTx(CTransaction{t}, max_op_return_relay, std::nullopt, g_bare_multi, g_dust, reason));
         BOOST_CHECK_EQUAL(reason_in, reason);
     };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -809,7 +809,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     std::string reason;
-    if (m_pool.m_opts.require_standard && !IsStandardTx(tx, m_pool.m_opts.max_datacarrier_bytes, m_pool.m_opts.permit_bare_multisig, m_pool.m_opts.dust_relay_feerate, reason)) {
+    if (m_pool.m_opts.require_standard && !IsStandardTx(tx, m_pool.m_opts.max_datacarrier_bytes, m_pool.m_opts.min_datacarrier_bytes, m_pool.m_opts.permit_bare_multisig, m_pool.m_opts.dust_relay_feerate, reason)) {
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, reason);
     }
 

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -47,7 +47,6 @@ class DataCarrierTest(BitcoinTestFramework):
             self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_hex)
             assert tx.txid_hex in node.getrawmempool(True), f'{tx_hex} not in mempool'
         else:
-            # Error message could be either "datacarrier" or "datacarrier-too-small"
             assert_raises_rpc_error(-26, "datacarrier", self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
 
     def run_test(self):

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -26,12 +26,13 @@ CUSTOM_DATACARRIER_ARG = 83
 
 class DataCarrierTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 4
+        self.num_nodes = 5
         self.extra_args = [
             [], # default is uncapped
             ["-datacarrier=0"], # no relay of datacarrier
             ["-datacarrier=1", f"-datacarriersize={CUSTOM_DATACARRIER_ARG}"],
             ["-datacarrier=1", "-datacarriersize=2"],
+            ["-datacarrier=1", "-mindatacarriersize=10"], # minimum size of 10 bytes
         ]
 
     def test_null_data_transaction(self, node: TestNode, data, success: bool) -> None:
@@ -46,6 +47,7 @@ class DataCarrierTest(BitcoinTestFramework):
             self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_hex)
             assert tx.txid_hex in node.getrawmempool(True), f'{tx_hex} not in mempool'
         else:
+            # Error message could be either "datacarrier" or "datacarrier-too-small"
             assert_raises_rpc_error(-26, "datacarrier", self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
 
     def run_test(self):
@@ -58,6 +60,7 @@ class DataCarrierTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getmempoolinfo()["maxdatacarriersize"], 0)
         assert_equal(self.nodes[2].getmempoolinfo()["maxdatacarriersize"], CUSTOM_DATACARRIER_ARG)
         assert_equal(self.nodes[3].getmempoolinfo()["maxdatacarriersize"], 2)
+        assert_equal(self.nodes[4].getmempoolinfo()["mindatacarriersize"], 10)
 
         # By default, any size is allowed.
 
@@ -100,9 +103,32 @@ class DataCarrierTest(BitcoinTestFramework):
         self.test_null_data_transaction(node=self.nodes[2], data=one_byte, success=True)
         self.test_null_data_transaction(node=self.nodes[3], data=one_byte, success=False)
 
+        # Test -mindatacarriersize
+        # OP_RETURN + push opcode + data = total script size
+        # For 10 byte minimum: we need 7 bytes of data (1 OP_RETURN + 1 push opcode + 7 data = 9 bytes)
+        # Actually for 10 bytes: we need 8 bytes of data (1 OP_RETURN + 1 push opcode + 8 data = 10 bytes)
+        nine_byte_script = randbytes(7)  # Will create 9 byte script (below minimum)
+        ten_byte_script = randbytes(8)   # Will create 10 byte script (exactly at minimum)
+        eleven_byte_script = randbytes(9) # Will create 11 byte script (above minimum)
+
+        self.log.info("Testing minimum datacarrier size with no OP_RETURN (should fail).")
+        tx_no_opreturn = self.wallet.create_self_transfer(fee_rate=0)["tx"]
+        tx_no_opreturn.vout[0].nValue -= tx_no_opreturn.get_vsize()
+        assert_raises_rpc_error(-26, "datacarrier-too-small", self.wallet.sendrawtransaction, from_node=self.nodes[4], tx_hex=tx_no_opreturn.serialize().hex())
+
+        self.log.info("Testing minimum datacarrier size below minimum (9 bytes, minimum is 10).")
+        self.test_null_data_transaction(node=self.nodes[4], data=nine_byte_script, success=False)
+
+        self.log.info("Testing minimum datacarrier size exactly at minimum (10 bytes).")
+        self.test_null_data_transaction(node=self.nodes[4], data=ten_byte_script, success=True)
+
+        self.log.info("Testing minimum datacarrier size above minimum (11 bytes).")
+        self.test_null_data_transaction(node=self.nodes[4], data=eleven_byte_script, success=True)
+
         # Clean shutdown boilerplate due to deprecation
         self.expected_stderr = [
             "",  # node 0 has no deprecated options
+            "Warning: Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated and are expected to be removed in a future version.",
             "Warning: Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated and are expected to be removed in a future version.",
             "Warning: Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated and are expected to be removed in a future version.",
             "Warning: Options '-datacarrier' or '-datacarriersize' are set but are marked as deprecated and are expected to be removed in a future version.",


### PR DESCRIPTION
There is a `(max)datacarriersize`, so this adds a `mindatacarriersize` for completeness

With tests:

```
$ ./test/functional/mempool_datacarrier.py
```

<img width="1500" height="375" alt="image" src="https://github.com/user-attachments/assets/b79a6a27-48e5-4480-8d9c-d4ec1cb03865" />
